### PR TITLE
small fixes and prompts for quaero

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -27,7 +27,7 @@ env.globals.update(zip=zip)
 # These are users whose datasets should be included in the results returned by
 # filter_english_datasets (regardless of their metadata)
 
-INCLUDED_USERS = {"Zaid", "craffel", "GEM", "aps", "khalidalt", "shanya", "rbawden", "BigScienceBiasEval", "gsarti", "Jean-Baptiste"}
+INCLUDED_USERS = {"Zaid", "craffel", "GEM", "aps", "khalidalt", "shanya", "rbawden", "BigScienceBiasEval", "gsarti", "Jean-Baptiste", "meczifho"}
 
 # These are the metrics with which templates can be tagged
 METRICS = {

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -27,7 +27,7 @@ env.globals.update(zip=zip)
 # These are users whose datasets should be included in the results returned by
 # filter_english_datasets (regardless of their metadata)
 
-INCLUDED_USERS = {"Zaid", "craffel", "GEM", "aps", "khalidalt", "shanya", "rbawden", "BigScienceBiasEval", "gsarti"}
+INCLUDED_USERS = {"Zaid", "craffel", "GEM", "aps", "khalidalt", "shanya", "rbawden", "BigScienceBiasEval", "gsarti", "Jean-Baptiste"}
 
 # These are the metrics with which templates can be tagged
 METRICS = {

--- a/promptsource/templates/meczifho/quaero/templates.yaml
+++ b/promptsource/templates/meczifho/quaero/templates.yaml
@@ -99,6 +99,42 @@ templates:
       original_task: false
     name: list-PROC
     reference: list-PROC
+  a69c1415-103c-4fa3-aefb-ccfd8d754e11: !Template
+    answer_choices: "partie du corps|||\xEAtre vivant|||sympt\xF4me ou maladie|||proc\xE9\
+      dure m\xE9dicale|||composant chimique ou m\xE9dicament|||zone g\xE9ographique|||physiologie|||ph\xE9\
+      nom\xE8ne|||objet|||appareil"
+    id: a69c1415-103c-4fa3-aefb-ccfd8d754e11
+    jinja: "{% set entities = [] %}{% set entity_types = [] %}{% set prev_entities\
+      \ = [None] %}{% for idx in range(ner_tags|length) %}{% if ner_tags[idx] != 0\
+      \ %}{% if ner_tags[idx] != prev_entities[idx] %}{{ entities.append([])|default(\"\
+      \", True) }}{{ entity_types.append(ner_tags[idx])|default(\"\", True) }}{% endif\
+      \ %}{{ entities[-1].append(words[idx])|default(\"\", True)  }}{% endif %}{{\
+      \ prev_entities.append(ner_tags[idx])|default(\"\", True) }}{% endfor %}{% set\
+      \ rand_idx = range(entities|length)|random %}{% if entities|length > 0 %}Dans\
+      \ le texte suivant, \"{% for idx in range(entities[rand_idx]|length) %}{{ entities[rand_idx][idx]\
+      \ }}{% if idx+1 < entities[rand_idx]|length %}{% if (entities[rand_idx][idx+1]\
+      \ not in \"])'/\u2019.,%-\u20AC$\xA3\\\")\" and entities[rand_idx][idx][-1]\
+      \ not in \"'[(/\u2019-\") %} {% endif %}{% endif %}{% endfor %}\" est de quel\
+      \ type entre \"partie du corps\", \"\xEAtre vivant\", \"sympt\xF4me ou maladie\"\
+      , \"proc\xE9dure m\xE9dicale\", \"composant chimique ou m\xE9dicament\", \"\
+      zone g\xE9ographique\", \"physiologie\", \"ph\xE9nom\xE8ne\", \"objet\" ou \"\
+      appareil ? \n\n{% for idx in range(words|length) %}{{ words[idx] }}{% if idx+1\
+      \ < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC$\xA3\\\"\
+      )\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif %}{% endfor\
+      \ %}{% endif %}\n||| {% if entity_types[rand_idx] == 1 %}partie du corps{%elif\
+      \ entity_types[rand_idx] == 2 %}\xEAtre vivant{%elif entity_types[rand_idx]\
+      \ == 3 %}sympt\xF4me ou maladie{%elif entity_types[rand_idx] == 4 %}proc\xE9\
+      dure m\xE9dicale{%elif entity_types[rand_idx] == 5 %}composant chimique ou m\xE9\
+      dicament{%elif entity_types[rand_idx] == 6 %}zone g\xE9ographique{%elif entity_types[rand_idx]\
+      \ == 7 %}physiologie{%elif entity_types[rand_idx] == 8 %}ph\xE9nom\xE8ne{%elif\
+      \ entity_types[rand_idx] == 9 %}objet{%elif entity_types[rand_idx] == 10 %}appareil{%endif%}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics: []
+      original_task: false
+    name: choose-entity
+    reference: choose-entity
   a6b1d3a2-9be4-4286-b921-fb1a1e59a541: !Template
     answer_choices: null
     id: a6b1d3a2-9be4-4286-b921-fb1a1e59a541

--- a/promptsource/templates/meczifho/quaero/templates.yaml
+++ b/promptsource/templates/meczifho/quaero/templates.yaml
@@ -1,0 +1,200 @@
+dataset: meczifho/quaero
+templates:
+  34a46bfe-97eb-44f7-abfc-b22b944be59f: !Template
+    answer_choices: null
+    id: 34a46bfe-97eb-44f7-abfc-b22b944be59f
+    jinja: "{% set ner_num = 10 %}\nLister les entit\xE9s de type \"appareil\" dans\
+      \ le texte suivant : {% for idx in range(words|length) %}{{ words[idx] }}{%\
+      \ if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-DEVI
+    reference: list-DEVI
+  36316877-8a0d-433a-b0d8-ac426a9ee922: !Template
+    answer_choices: null
+    id: 36316877-8a0d-433a-b0d8-ac426a9ee922
+    jinja: "{% set ner_num = 6 %}\nLister les entit\xE9s de type \"zone g\xE9ographique\"\
+      \ dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-GEOG
+    reference: list-GEOG
+  471abd04-f81f-4546-80cf-28a2a1db54e6: !Template
+    answer_choices: null
+    id: 471abd04-f81f-4546-80cf-28a2a1db54e6
+    jinja: "{% set ner_num = 9 %}\nLister les entit\xE9s de type \"objet\" dans le\
+      \ texte suivant : {% for idx in range(words|length) %}{{ words[idx] }}{% if\
+      \ idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC$\xA3\
+      \\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif %}{%\
+      \ endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}\n"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-OBJC
+    reference: list-OBJC
+  7ba4da6f-9043-42f7-9645-8fe5548d9480: !Template
+    answer_choices: null
+    id: 7ba4da6f-9043-42f7-9645-8fe5548d9480
+    jinja: "{% set ner_num = 2 %}\nLister les entit\xE9s de type \"\xEAtre vivant\"\
+      \ dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-LIVB
+    reference: list-LIVB
+  a428821a-cba4-4c43-aeba-f4a5c95beec4: !Template
+    answer_choices: null
+    id: a428821a-cba4-4c43-aeba-f4a5c95beec4
+    jinja: "{% set ner_num = 4 %}\nLister les entit\xE9s de type \"proc\xE9dure m\xE9\
+      dicale\" dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+      - Edit Distance
+      original_task: false
+    name: list-PROC
+    reference: list-PROC
+  a6b1d3a2-9be4-4286-b921-fb1a1e59a541: !Template
+    answer_choices: null
+    id: a6b1d3a2-9be4-4286-b921-fb1a1e59a541
+    jinja: "{% set ner_num = 3 %}\nLister les entit\xE9s de type \"maladie ou sympt\xF4\
+      me\" dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-DISO
+    reference: list-DISO
+  ac549f30-b4c3-4238-8aef-dbcf0fb64bd6: !Template
+    answer_choices: null
+    id: ac549f30-b4c3-4238-8aef-dbcf0fb64bd6
+    jinja: "{% set ner_num = 7 %}\nLister les entit\xE9s de type \"physiologie\" dans\
+      \ le texte suivant : {% for idx in range(words|length) %}{{ words[idx] }}{%\
+      \ if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-PHYS
+    reference: list-PHYS
+  c2fb4614-8321-4e74-bfdf-50535e0aab64: !Template
+    answer_choices: null
+    id: c2fb4614-8321-4e74-bfdf-50535e0aab64
+    jinja: "{% set ner_num = 1 %}\nLister les entit\xE9s de type \"partie du corps\"\
+      \ dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-ANAT
+    reference: list-ANAT
+  cd73f07e-acab-4150-a677-5442b4ca4d31: !Template
+    answer_choices: null
+    id: cd73f07e-acab-4150-a677-5442b4ca4d31
+    jinja: "{% set ner_num = 5 %}\nLister les entit\xE9s de type \"composant chimique\
+      \ ou m\xE9dicament\" dans le texte suivant : {% for idx in range(words|length)\
+      \ %}{{ words[idx] }}{% if idx+1 < words|length %}{% if (words[idx+1] not in\
+      \ \"])'/\u2019.,%-\u20AC$\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019\
+      -\") %} {% endif %}{% endif %}{% endfor %}||| \n{% for idx in range(ner_tags|length)\
+      \ %}{% if ner_tags[idx] == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1\
+      \ < ner_tags|length %}{% if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1]\
+      \ != ner_num  %}\n{% else %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-CHEM
+    reference: list-CHEM
+  eb5b6f69-6834-4301-a153-546033427be1: !Template
+    answer_choices: null
+    id: eb5b6f69-6834-4301-a153-546033427be1
+    jinja: "{% set ner_num = 8 %}\nLister les entit\xE9s de type \"ph\xE9nom\xE8ne\"\
+      \ dans le texte suivant : {% for idx in range(words|length) %}{{ words[idx]\
+      \ }}{% if idx+1 < words|length %}{% if (words[idx+1] not in \"])'/\u2019.,%-\u20AC\
+      $\xA3\\\")\" and words[idx][-1] not in \"'[(/\u2019-\") %} {% endif %}{% endif\
+      \ %}{% endfor %}||| \n{% for idx in range(ner_tags|length) %}{% if ner_tags[idx]\
+      \ == ner_num %}{{ words[idx] }}{% endif %}{% if idx+1 < ner_tags|length %}{%\
+      \ if ner_tags[idx] == ner_num %}{% if ner_tags[idx+1] != ner_num  %}\n{% else\
+      \ %} {% endif %}{% endif %}{% endif %}{% endfor %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages:
+      - fr
+      metrics:
+      - Edit Distance
+      original_task: true
+    name: list-PHEN
+    reference: list-PHEN

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -2,7 +2,7 @@
 import os
 
 import datasets
-import requests
+from huggingface_hub import HfApi
 
 from promptsource import DEFAULT_PROMPTSOURCE_CACHE_HOME
 from promptsource.templates import INCLUDED_USERS
@@ -115,11 +115,11 @@ def filter_datasets():
     """
     filtered_datasets = []
 
-    response = requests.get("https://huggingface.co/api/datasets?full=true")
-    tags = response.json()
+    api = HfApi()
+    tags = api.list_datasets()
 
     for dataset in tags:
-        dataset_name = dataset["id"]
+        dataset_name = dataset.id
 
         is_community_dataset = "/" in dataset_name
         if is_community_dataset:


### PR DESCRIPTION
In addition to updating the INCLUDED_USERS list, I suggest using the HfApi in filter_datasets().
As per https://huggingface.co/docs/hub/api, the /api/datasets GET request generates a **paginated** response. This explains why some HF datasets do not appear in the dataset menu in Sourcing mode. So one can either deal with this pagination using link headers, or directly use the HfApi library, which seems to be cleaner and more adapted to this use.

Update : added some prompts for meczifho/quaero and added meczifho to list INCLUDED_USERS